### PR TITLE
Support NO_COLOR (https://no-color.org)

### DIFF
--- a/cmd/gopm/main.go
+++ b/cmd/gopm/main.go
@@ -21,7 +21,11 @@ import (
 
 func init() {
 	cfg := zap.NewDevelopmentConfig()
-	cfg.Encoding = "term-color"
+	encoding := "term-color"
+	if os.Getenv("NO_COLOR") != "" {
+		encoding = "term"
+	}
+	cfg.Encoding = encoding
 	cfg.DisableStacktrace = true
 	cfg.EncoderConfig = encoder.NewDevelopmentEncoderConfig()
 	cfg.EncoderConfig.CallerKey = ""


### PR DESCRIPTION
This adds support for `NO_COLOR` environment variable: https://no-color.org

I have a bit easier time reading output when it isn't colorized.