### PR TITLE
Fix configuration changes not recognizing deleted processes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,9 @@ require (
 	github.com/rakyll/statik v0.1.7
 	github.com/ramr/go-reaper v0.2.0
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e
 	github.com/spf13/afero v1.1.2
+	github.com/spf13/cast v1.3.0
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/multierr v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/set v0.2.1 h1:nn2CaJyknWE/6txyUDGwysr3G5QC6xWB/PtVjPBbeaA=
+github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0 h1:Wz+5lgoB0kkuqLEc6NVmwRknTKP6dTGbSqvhZtBI/j0=
@@ -141,8 +143,6 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/r3labs/diff v1.1.0 h1:V53xhrbTHrWFWq3gI4b94AjgEJOerO1+1l0xyHOBi8M=
-github.com/r3labs/diff v1.1.0/go.mod h1:7WjXasNzi0vJetRcB/RqNl5dlIsmXcTTLmF5IoH6Xig=
 github.com/r3labs/diff v1.1.1-0.20200602081335-2448fc76135e h1:q9TLfy8ivciRbi/CTX1bQnYInr/sD9jRxX2EMeGJApM=
 github.com/r3labs/diff v1.1.1-0.20200602081335-2448fc76135e/go.mod h1:7WjXasNzi0vJetRcB/RqNl5dlIsmXcTTLmF5IoH6Xig=
 github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=
@@ -154,12 +154,15 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e h1:7q6NSFZDeGfvvtIRwBrU/aegEYJYmvev0cHAwo17zZQ=
+github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=

--- a/pkg/cast/cast.go
+++ b/pkg/cast/cast.go
@@ -1,0 +1,22 @@
+package cast
+
+import "github.com/spf13/cast"
+
+func ToSliceE(i interface{}) ([]interface{}, error) {
+	var s []interface{}
+
+	switch v := i.(type) {
+	case []string:
+		for _, u := range v {
+			s = append(s, u)
+		}
+		return s, nil
+	}
+
+	return cast.ToSliceE(i)
+}
+
+func ToSlice(i interface{}) []interface{} {
+	v, _ := ToSliceE(i)
+	return v
+}

--- a/process/process.go
+++ b/process/process.go
@@ -228,9 +228,9 @@ func (p *Process) Start(wait bool) {
 }
 
 // Destroy stops the process and removes it from cron
-func (p *Process) Destroy() {
+func (p *Process) Destroy(wait bool) {
 	p.removeFromCron()
-	p.Stop(false)
+	p.Stop(wait)
 }
 
 // Name returns the name of program

--- a/process/process_manager_test.go
+++ b/process/process_manager_test.go
@@ -18,8 +18,8 @@ func TestProcMgrRemove(t *testing.T) {
 	var procs = NewManager()
 	procs.Clear()
 	procs.Add("test1", &Process{})
-	proc := procs.Remove("test1")
+	proc := procs.RemoveProcess("test1")
 	assert.NotNil(t, proc, "Failed to remove process")
-	proc = procs.Remove("test1")
+	proc = procs.RemoveProcess("test1")
 	assert.Nil(t, proc, "Unexpected value")
 }

--- a/supervisor_grpc.go
+++ b/supervisor_grpc.go
@@ -131,15 +131,15 @@ func (s *Supervisor) Shutdown(context.Context, *empty.Empty) (*empty.Empty, erro
 }
 
 func (s *Supervisor) ReloadConfig(context.Context, *empty.Empty) (*rpc.ReloadConfigResponse, error) {
-	addedGroup, changedGroup, removedGroup, err := s.Reload()
+	err := s.Reload()
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	return &rpc.ReloadConfigResponse{
-		AddedGroup:   addedGroup,
-		ChangedGroup: changedGroup,
-		RemovedGroup: removedGroup,
+		AddedGroup:   nil,
+		ChangedGroup: nil,
+		RemovedGroup: nil,
 	}, nil
 }
 


### PR DESCRIPTION
This PR fixes an issue when process configuration is removed from a config file, the associated process was not shutdown and deleted by the process manager.

Also cleans up the main gopm startup behavior.