### PR TITLE
feat: gopmctl top

### DIFF
--- a/cmd/gopmctl/top.go
+++ b/cmd/gopmctl/top.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/spf13/cobra"
+	"github.com/stuartcarnie/gopm/process"
+)
+
+var topCmd = cobra.Command{
+	Use:   "top",
+	Short: "Display the resource usage of a list of processes",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := control.client.GetProcessInfo(context.Background(), &empty.Empty{})
+		if err != nil {
+			return err
+		}
+		display := make(map[string]bool)
+		for _, process := range args {
+			display[process] = true
+
+		}
+		var usages []*processResourceUsage
+		for _, p := range res.Processes {
+			if !control.inProcessMap(p, display) {
+				continue
+			}
+			info, err := process.Stat(int(p.Pid))
+			if err != nil {
+				return err
+			}
+			usages = append(usages, &processResourceUsage{
+				ProcessInfo: p,
+				Usage:       info,
+			})
+		}
+		control.printTop(usages)
+		return nil
+	},
+}

--- a/process/usage.go
+++ b/process/usage.go
@@ -1,0 +1,48 @@
+package process
+
+import (
+	"fmt"
+)
+
+// ResourceUsage describes the system resource usage of a process.
+type ResourceUsage struct {
+	CPU      float64
+	Memory   float64
+	Resident int
+}
+
+// HumanResident returns a human readable version of the memory usage.
+func (r ResourceUsage) HumanResident() string {
+	return humanBytes(r.Resident)
+}
+
+// StatError is returned when Stat-ing a PID.
+type StatError struct {
+	PID int
+	Err error
+}
+
+// Error implements error
+func (e StatError) Error() string {
+	return fmt.Sprintf("failed to stat pid %d: %s", e.PID, e.Err)
+}
+
+// Unwrap allows StatError to be used with errors.Is/As.
+func (e StatError) Unwrap() error {
+	return e.Err
+}
+
+func humanBytes(b int) string {
+	const magnitudes = "kMGTPE"
+	const unit = 1000
+
+	if b < unit {
+		return fmt.Sprintf("%dB", b)
+	}
+	div, exp := int(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f%cB", float64(b)/float64(div), magnitudes[exp])
+}

--- a/process/usage_test.go
+++ b/process/usage_test.go
@@ -1,0 +1,27 @@
+package process
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHumanBytes(t *testing.T) {
+	tests := []struct {
+		in  int
+		out string
+	}{
+		{in: 1000, out: "1.0kB"},
+		{in: 10000, out: "10.0kB"},
+		{in: 1000000, out: "1.0MB"},
+		{in: 1500000, out: "1.5MB"},
+		{in: 2000000000, out: "2.0GB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%d", tt.in), func(t *testing.T) {
+			assert.Equal(t, tt.out, humanBytes(tt.in))
+		})
+	}
+}

--- a/process/usage_unix.go
+++ b/process/usage_unix.go
@@ -1,0 +1,54 @@
+package process
+
+import (
+	"errors"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// Stat gets the resource usage of a pid using `ps`.
+func Stat(pid int) (*ResourceUsage, error) {
+	cmd := exec.Command("ps", "-o pcpu,pmem,rss -p", strconv.Itoa(pid))
+	stdout, _ := cmd.Output()
+	split := strings.Split(string(stdout), "\n")
+	if len(split) == 0 {
+		return nil, StatError{
+			PID: pid,
+			Err: errors.New("no output from ps"),
+		}
+	}
+	fields := strings.Fields(split[1])
+	if len(fields) != 3 {
+		return nil, StatError{
+			PID: pid,
+			Err: errors.New("wrong number of fields in ps output"),
+		}
+	}
+	cpu, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return nil, StatError{
+			PID: pid,
+			Err: err,
+		}
+	}
+	pmem, err := strconv.ParseFloat(fields[1], 64)
+	if err != nil {
+		return nil, StatError{
+			PID: pid,
+			Err: err,
+		}
+	}
+	rss, err := strconv.Atoi(fields[2])
+	if err != nil {
+		return nil, StatError{
+			PID: pid,
+			Err: err,
+		}
+	}
+	return &ResourceUsage{
+		CPU:      cpu,
+		Memory:   pmem,
+		Resident: rss * 1000,
+	}, nil
+}

--- a/process/usage_windows.go
+++ b/process/usage_windows.go
@@ -1,0 +1,7 @@
+package process
+
+import "errors"
+
+func Stat(pid int) (*Info, error) {
+	return nil, errors.New("stat not implemented")
+}


### PR DESCRIPTION
Prints the resource usage of the processes owned by the `gopm` supervisor.

Currently assuming `pcpu,pmem,rss` fields from `ps` under Unix. I haven't implemented anything for Windows, because I'm not even sure the rest of this would work in that environment.

Here's what it looks like:

```
$ gopmctl top
etcd:etcd                 52671     0.4%      24.0MB (0.1%)
redis:redis               52669     0.0%      3.4MB (0.0%)
dex:dex                   52678     0.0%      15.2MB (0.1%)
stream:stream             52667     0.0%      9.2MB (0.1%)
queryd:queryd             52666     0.0%      52.0MB (0.3%)
influxqld:influxqld       52677     0.0%      19.8MB (0.1%)
storage:storage           52668     0.1%      22.7MB (0.1%)
gateway:gateway           52670     0.0%      51.7MB (0.3%)
tasks:tasks               52674     0.0%      44.0MB (0.3%)
chronograf:chronograf     52672     0.0%      22.7MB (0.1%)
telegraf:telegraf         52665     0.0%      28.0MB (0.2%)
```

I've chosen simple decimal SI measurements for memory here.