### PR TITLE
feat: Persistent logger for process

### DIFF
--- a/process/process_manager_test.go
+++ b/process/process_manager_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stuartcarnie/gopm/config"
-	"go.uber.org/zap"
 )
 
 func TestProcessMgrAdd(t *testing.T) {
@@ -18,10 +17,7 @@ func TestProcessMgrAdd(t *testing.T) {
 func TestProcMgrRemove(t *testing.T) {
 	var procs = NewManager()
 	procs.Clear()
-	procs.Add("test1", &Process{
-		log:    zap.NewNop(),
-		config: &config.Process{},
-	})
+	procs.Add("test1", NewProcess("1", &config.Process{}))
 	proc := procs.RemoveProcess("test1")
 	assert.NotNil(t, proc, "Failed to remove process")
 	proc = procs.RemoveProcess("test1")

--- a/supervisor_grpc.go
+++ b/supervisor_grpc.go
@@ -2,7 +2,6 @@ package gopm
 
 import (
 	"context"
-	"errors"
 	"os"
 	"time"
 
@@ -154,20 +153,11 @@ func (s *Supervisor) TailLog(req *rpc.TailLogRequest, stream rpc.Gopm_TailLogSer
 		return status.Error(codes.NotFound, "Process not found")
 	}
 
-	var (
-		ok              bool
-		compositeLogger *logger.CompositeLogger
-		backlog         *process.RingBuffer
-	)
-	if req.Device == rpc.LogDevice_Stdout {
-		compositeLogger, ok = proc.StdoutLog.(*logger.CompositeLogger)
-		backlog = proc.StdoutBacklog
-	} else {
-		compositeLogger, ok = proc.StderrLog.(*logger.CompositeLogger)
+	compositeLogger := proc.StdoutLog
+	backlog := proc.StdoutBacklog
+	if req.Device == rpc.LogDevice_Stderr {
+		compositeLogger = proc.StderrLog
 		backlog = proc.StderrBacklog
-	}
-	if !ok {
-		return errors.New("cannot register with existing logger")
 	}
 
 	var (


### PR DESCRIPTION
Loggers currently get thrown away every time the Process restarts. This causes issues for `gopmctl logs` following, because when the Process restarts, `logs` remains attached to a logger that won't be receiving logs from the new Process command instance.

This establishes a persistent `logger.CompositeLogger` that remains for the entire lifecycle of a Process. Each time a Process's command is started, new loggers are created and mounted to the persistent logger.

You are now able to leave `gopmctl logs <process>` running and do things like `gopmctl stop <process>` and `gopmctl start <process>` and still see log output.