### PR TITLE
fix(supervisor): Inspect the error before the change list

### DIFF
--- a/cmd/gopm/main.go
+++ b/cmd/gopm/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -61,6 +62,10 @@ func runServer() error {
 
 	s := gopm.NewSupervisor(rootOpt.Configuration)
 	if err := s.Reload(); err != nil {
+		// Ignore config loading errors, because the Supervisor logs those.
+		if errors.As(err, &gopm.SupervisorConfigError{}) {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
The checking `changes` before `err` is causing the error output to be ignored, resulting in a process that appears to hang. Now when there's an error parsing the YAML document we get our error output.

Also introduces a wrapping error type so that the CLI can safely ignore errors coming from within the Supervisor layer. This let's us continue to log these parsing errors inside the Supervisor and have a good experience when acting through gRPC and when doing the initial load on start. If we returned an error in the CLI layer, it would be printed out (again) along with the help documentation; this isn't what we want.