### PR TITLE
move shell to config

### DIFF
--- a/cmd/gopm/main.go
+++ b/cmd/gopm/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 
 	"github.com/stuartcarnie/gopm"
 	"github.com/stuartcarnie/gopm/internal/zap/encoder"
-	"github.com/stuartcarnie/gopm/process"
 )
 
 func main() {
@@ -78,26 +76,15 @@ var (
 	rootOpt = struct {
 		Configuration string
 		EnvFile       string
-		Shell         string
 		QuitDelay     time.Duration
 	}{}
 
 	rootCmd = cobra.Command{
 		RunE: func(cmd *cobra.Command, args []string) error {
-			process.SetShellArgs(strings.Split(rootOpt.Shell, " "))
 			return runServer()
 		},
 	}
 )
-
-func getDefaultShell() string {
-	sh := os.Getenv("SHELL")
-	if sh == "" {
-		return "/bin/sh -c"
-	}
-
-	return sh + " -c"
-}
 
 func Main() int {
 	gopm.ReapZombie()
@@ -105,7 +92,6 @@ func Main() int {
 	rootCmd.PersistentFlags().StringVarP(&rootOpt.Configuration, "config", "c", "", "Configuration file")
 	flags := rootCmd.Flags()
 	flags.StringVar(&rootOpt.EnvFile, "env-file", "", "An optional environment file")
-	flags.StringVar(&rootOpt.Shell, "shell", getDefaultShell(), "Specify an alternate shell path")
 	flags.DurationVar(&rootOpt.QuitDelay, "quit-delay", time.Second, "Time to wait for second CTRL-C before quitting. 0 to quit immediately.")
 	_ = rootCmd.MarkFlagRequired("config")
 

--- a/config/config.go
+++ b/config/config.go
@@ -166,31 +166,31 @@ type RuntimeConfig struct {
 }
 
 type Program struct {
-	Name                     string            `json:"name"`
-	Directory                string            `json:"directory"`
-	Command                  string            `json:"command"`
-	Environment              map[string]string `json:"environment"`
-	User                     string            `json:"user"`
-	ExitCodes                []int             `json:"exit_codes"`
-	Priority                 int               `json:"priority"`
-	RestartPause             Duration          `json:"restart_pause"`
-	StartRetries             int               `json:"start_retries"`
-	StartSeconds             Duration          `json:"start_seconds"`
-	Cron                     string            `json:"cron"`
-	AutoStart                bool              `json:"auto_start"`
-	AutoRestart              *bool             `json:"auto_restart,omitempty"`
-	RestartDirectoryMonitor  string            `json:"restart_directory_monitor"`
-	RestartFilePattern       string            `json:"restart_file_pattern"`
-	RestartWhenBinaryChanged bool              `json:"restart_when_binary_changed"`
-	StopSignals              []string          `json:"stop_signals"`
-	StopWaitSeconds          Duration          `json:"stop_wait_seconds"`
-	StopAsGroup              bool              `json:"stop_as_group"`
-	KillAsGroup              bool              `json:"kill_as_group"`
-	LogFile                  string            `json:"logfile"`
-	LogfileBackups           int               `json:"logfile_backups"`
-	LogFileMaxBytes          int               `json:"logfile_max_bytes"`
-	DependsOn                []string          `json:"depends_on"`
-	Labels                   map[string]string `json:"labels"`
+	Name                    string            `json:"name"`
+	Directory               string            `json:"directory"`
+	Command                 string            `json:"command"`
+	Shell                   string            `json:"shell"`
+	Environment             map[string]string `json:"environment"`
+	User                    string            `json:"user"`
+	ExitCodes               []int             `json:"exit_codes"`
+	Priority                int               `json:"priority"`
+	RestartPause            Duration          `json:"restart_pause"`
+	StartRetries            int               `json:"start_retries"`
+	StartSeconds            Duration          `json:"start_seconds"`
+	Cron                    string            `json:"cron"`
+	AutoStart               bool              `json:"auto_start"`
+	AutoRestart             *bool             `json:"auto_restart,omitempty"`
+	RestartDirectoryMonitor string            `json:"restart_directory_monitor"`
+	RestartFilePattern      string            `json:"restart_file_pattern"`
+	StopSignals             []string          `json:"stop_signals"`
+	StopWaitSeconds         Duration          `json:"stop_wait_seconds"`
+	StopAsGroup             bool              `json:"stop_as_group"`
+	KillAsGroup             bool              `json:"kill_as_group"`
+	LogFile                 string            `json:"logfile"`
+	LogfileBackups          int               `json:"logfile_backups"`
+	LogFileMaxBytes         int               `json:"logfile_max_bytes"`
+	DependsOn               []string          `json:"depends_on"`
+	Labels                  map[string]string `json:"labels"`
 }
 
 type Server struct {

--- a/config/schema.cue
+++ b/config/schema.cue
@@ -61,9 +61,19 @@ import (
 }
 
 #Program: {
+	// name holds the name of the program. This is implied
+	// from the name of the program entry.
 	name:       =~"^\\w+$"
+
+	// directory holds the directory in which to run the program.
 	directory?: string
+
+	// command holds the command to run the program.
 	command:    string & =~ "."
+
+	// shell specifies the shell command to use to interpret the
+	// above command. The shell is invoked as $shell -c $command.
+	shell?: string
 
 	// A list of process names that must be started before starting
 	// this process.
@@ -119,13 +129,6 @@ import (
 	// when restart_directory_monitor is set.
 	restart_file_pattern?: string
 
-	// restart_when_binary_changed indicates whether the process is
-	// automatically restarted if changes to the binary are detected.
-	// Note: this is currently broken - it assumes that the "binary" is determined
-	// by the first word of the command and that it lives directly inside the program's directory.
-	// TODO fix this comment when it's working properly again.
-	restart_when_binary_changed?: bool
-
 	// stop_signals holds a list of signals to send in order to try to kill the running process.
 	// There will be a pause of stop_wait_seconds after each attempt.
 	stop_signals?:                [..."HUP" | "INT" | "QUIT" | "KILL" | "TERM" | "USR1" | "USR2"]
@@ -151,9 +154,9 @@ import (
 
 #ConfigWithDefaults: #Config &  {
 	runtime: _
-	...
 	programs: [_]: #Program & {
 		directory: *runtime.cwd | _
+		shell: *"/bin/sh" | _
 		exit_codes: *[0, 2] | _
 		priority: *999 | _
 		start_retries: *3 | _

--- a/process/process_manager.go
+++ b/process/process_manager.go
@@ -21,7 +21,7 @@ type Manager struct {
 	lock  sync.Mutex
 }
 
-// NewManager create a new Manager object
+// NewManager returns a new Manager holding no processes.
 func NewManager() *Manager {
 	return &Manager{
 		procs: make(map[string]*process),


### PR DESCRIPTION
Having the shell as a command-line value that defaults
to $SHELL doesn't really make sense, as the interpretation
of the commands in a `gopm` config file shouldn't vary depending
on the environment they're run in. Instead, make the shell
a property of each program, defaulting to `/bin/sh`.

Also remove the restart-when-binary-changed functionality
as it's currently somewhat broken and doesn't really make sense
in general when commands are shell scripts. It can be added
back later with rethought semantics.
