### PR TITLE
better config verification

### DIFF
--- a/cmd/gopm/testdata/cyclic-depends.txt
+++ b/cmd/gopm/testdata/cyclic-depends.txt
@@ -1,0 +1,30 @@
+# Test that a configuration with cyclic dependencies is an error.
+
+# Start it up. It should fail immediately with an error.
+gopm -c gopmconfig --quit-delay 0 &
+wait
+stderr 'Error loading configuration  	error:cyclic dependency involving ("b" and "a")|("a" and "b")'
+
+-- gopmconfig/config.cue --
+package config
+
+grpc_server: {
+	network: "unix"
+	address: "gopm.socket"
+}
+programs: {
+	a: {
+		command: " "
+		depends_on: ["b", "c"]
+	}
+	b: {
+		command: " "
+		depends_on: ["d", "a"]
+	}
+	c: {
+		command: " "
+	}
+	d: {
+		command: " "
+	}
+}

--- a/cmd/gopm/testdata/non-existent-depends.txt
+++ b/cmd/gopm/testdata/non-existent-depends.txt
@@ -1,0 +1,20 @@
+# Test that a configuration with dependencies that don't exist is an error
+
+# Start it up. It should fail immediately with an error.
+gopm -c gopmconfig --quit-delay 0 &
+wait
+stderr 'Error loading configuration  	error:program "a" has dependency on non-existent program "b"'
+
+-- gopmconfig/config.cue --
+package config
+
+grpc_server: {
+	network: "unix"
+	address: "gopm.socket"
+}
+programs: {
+	a: {
+		command: " "
+		depends_on: ["b"]
+	}
+}

--- a/config/schema.cue
+++ b/config/schema.cue
@@ -87,12 +87,6 @@ import (
 	// user holds the username to run the process as.
 	user?: string
 
-	// priority holds the startup-order priority of the process.
-	// In the absence of a "depends_on" relationship, this
-	// determines the startup and shutdown order of processes.
-	// Higher priority programs will start up later and shut down earlier.
-	priority?:      int
-
 	// restart_pause holds the length of time to wait after a program
 	// has exited before auto-restarting it.
 	restart_pause?: int
@@ -158,7 +152,6 @@ import (
 		directory: *runtime.cwd | _
 		shell: *"/bin/sh" | _
 		exit_codes: *[0, 2] | _
-		priority: *999 | _
 		start_retries: *3 | _
 		start_seconds: *"1s" | _
 		auto_start: *true | _


### PR DESCRIPTION
Verify cron values when parsing; also verify depends_on relationships,
meaning that we can assume later in the code that there are no cyclic
dependencies to get us into recursive trouble.

Also remove the `priority` field from the configuration as it's of marginal
use since we now have `depends_on` which wasn't present in the
original `supervisord` configuration from which this is derived.
