### PR TITLE
process: support cron schedules

### DIFF
--- a/cmd/gopm/testdata/cron.txt
+++ b/cmd/gopm/testdata/cron.txt
@@ -1,0 +1,28 @@
+gopm -c gopmconfig --quit-delay 0 &
+# When the output file is created, we know we're near a second
+# boundary, so waiting over 3 seconds should result in three
+# more lines in the file.
+waitfile outfile
+exec sleep 3.8
+cmp outfile expect-outfile
+gopmctl --addr unix:gopm.socket shutdown
+wait
+-- gopmconfig/config.cue --
+package config
+
+config: grpc_server: {
+	network: "unix"
+	address: "gopm.socket"
+}
+
+config: programs: repeat: {
+	command: "echo hello >> outfile"
+	auto_start: false
+	// Run every second.
+	cron: "* * * * * *",
+}
+-- expect-outfile --
+hello
+hello
+hello
+hello

--- a/config/config.go
+++ b/config/config.go
@@ -95,7 +95,7 @@ func load0(configDir string) (*Config, error) {
 	// Make sure the config value is there before we fill it in with
 	// our own schema.
 	if val := val.LookupPath(pathConfig); val.Err() != nil {
-		return nil, fmt.Errorf("cannot get \"gopm\" value containing configuration: %w", err)
+		return nil, fmt.Errorf("cannot get \"gopm\" value containing configuration: %w", val.Err())
 	}
 
 	// Load the schema and defaults from our embedded CUE file (see schema.cue).
@@ -349,7 +349,11 @@ func (sched *CronSchedule) UnmarshalJSON(data []byte) error {
 		sched.String = ""
 		return nil
 	}
-	parser := cron.NewParser(cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+	// Note: the below options are equivalent to the cron.WithSeconds
+	// scheduler option.
+	parser := cron.NewParser(
+		cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
+	)
 	schedule, err := parser.Parse(s)
 	if err != nil {
 		return fmt.Errorf("cannot parse cron entry: %v", err)

--- a/config/schema.cue
+++ b/config/schema.cue
@@ -101,7 +101,7 @@ config: #Config
 	start_seconds?: time.Duration
 
 	// cron holds a cron schedule for running the program.
-	cron?: string // TODO validate this
+	cron?: string
 
 	// auto_start indicates whether the program should start automatically when
 	// gopm is started.


### PR DESCRIPTION
We don't need the scheduler functionality of the cron package
because our own process controller goroutine makes it unnecessary.