### PR TITLE
improve CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,25 +10,32 @@ on:
     - feature-cue
 jobs:
   go-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [1.17.x]
+        os: [ubuntu-latest, macos-latest]
     name: Go Test
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.17
+        go-version: ${{ matrix.go-version }}
       id: go
 
     - name: Checkout
       uses: actions/checkout@v2
 
-    # TODO(brett): This keeps seeing adding "google.golang.org/protobuf v1.23.0"
-    # and failing.
-    # - name: Verify Tidy
-    #   run: |
-    #     make
-    #     go mod tidy
-    #     git diff --exit-code
-
     - name: Test
-      run: go test -v ./...
+      run: |
+        go test ./...
+        go test -race ./...
+
+    - name: Tidy
+      if: matrix.os == 'ubuntu-latest' # no need to do this everywhere
+      run: |
+        go mod tidy
+
+        test -z "$(gofmt -d .)" || (gofmt -d . && false)
+        test -z "$(git status --porcelain)" || (git status; git diff && false)

--- a/cmd/gopmctl/main.go
+++ b/cmd/gopmctl/main.go
@@ -1,4 +1,3 @@
-
 package main
 
 import (

--- a/process/procattr_linux.go
+++ b/process/procattr_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package process

--- a/process/procattr_other.go
+++ b/process/procattr_other.go
@@ -1,5 +1,5 @@
-// +build !linux
-// +build !windows
+//go:build !linux && !windows
+// +build !linux,!windows
 
 package process
 
@@ -10,6 +10,6 @@ import (
 
 func setProcAttr(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid:   true,
+		Setpgid: true,
 	}
 }

--- a/process/procattr_windows.go
+++ b/process/procattr_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package process

--- a/process/process.go
+++ b/process/process.go
@@ -49,7 +49,7 @@ func (p State) String() string {
 	}
 }
 
-//go:generate stringer -type processRequestKind
+//go:generate go run golang.org/x/tools/cmd/stringer@v0.1.8 -type processRequestKind
 
 type processRequestKind int
 

--- a/signals/signal.go
+++ b/signals/signal.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package signals

--- a/signals/signal_windows.go
+++ b/signals/signal_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package signals

--- a/supervisor_grpc.go
+++ b/supervisor_grpc.go
@@ -61,9 +61,10 @@ func (s *Supervisor) StopAllProcesses(_ context.Context, req *rpc.StartStopAllRe
 
 func (s *Supervisor) Shutdown(context.Context, *empty.Empty) (*empty.Empty, error) {
 	s.mu.Lock()
-	if s.done != nil {
+	select {
+	case <-s.done:
+	default:
 		close(s.done)
-		s.done = nil
 	}
 	s.mu.Unlock()
 	return &empty.Empty{}, nil

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,11 @@
+//go:build tools
+// +build tools
+
+package tools
+
+// This is a kinda hack to ensure that the gopm module has dependencies
+// on the Go tools that are used for code generation.
+
+import (
+	_ "github.com/golang/protobuf/protoc-gen-go"
+)

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,7 +1,0 @@
-// +build tools
-
-package tools
-
-import (
-	_ "github.com/golang/protobuf/protoc-gen-go"
-)


### PR DESCRIPTION
We make the tests run on Darwin as well as Ubuntu (let's leave
Windows for now :) ) and reinstate the `go mod tidy` test in the
hope that it's better now.

The main motivation for this is because the new fswatcher package
tests have Darwin-specific code which is hard to test otherwise.