### PR TITLE
process: fix retry logic

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,22 @@
+## core
+
 - [ ] respect topological order when stopping processes on request
+- [x] allow empty commands
+- [ ] oneshot attribute
+- [ ] file tree watching
+- [ ] add `-a` (`--all`) flag to `gopmctl logs` command to print all the available logs for a process
+- [x] implement process signaling
+
+## docs
+- [ ] tutorial
+- [ ] reference
+
+## config
 - [ ] find configuration file automatically if none is explicitly specified
 - [ ] `gopm init` command to initialize a configuration file
 - [ ] support individual config file rather than just directory?
 - [ ] provide `gopm` package as overlay when reading configuration so users don't need to explicitly vendor it (and risk it getting out of date)
-- [ ] rename `gopm` package so the identifier doesn't clash with the `gopm` top level value (or rename that value to something else)
-- [ ] set user ID when specified
 - [ ] print configuration errors consistently and return them all via gRPC so that a `gopmctl reload` command will see them
-- [ ] documentation!
-- [ ] add `-a` (`--all`) flag to `gopmctl logs` command to print all the available logs for a process
 
+# later
+- [ ] set user ID when specified

--- a/cmd/gopm/testdata/retry.txt
+++ b/cmd/gopm/testdata/retry.txt
@@ -1,0 +1,38 @@
+# Test that a program is only restarted the correct number of times.
+gopm -c gopmconfig --quit-delay 0 &
+waitfile failing.txt
+exec sleep 1
+cmp failing.txt expect-failing.txt
+rm failing.txt
+
+# Test that it tries again from scratch when we
+# start it
+
+gopmctl --addr unix:gopm.socket start failing
+waitfile failing.txt
+exec sleep 1
+cmp failing.txt expect-failing.txt
+
+gopmctl --addr unix:gopm.socket shutdown
+wait
+
+-- gopmconfig/config.cue --
+package config
+
+config: grpc_server: {
+	network: "unix"
+	address: "gopm.socket"
+}
+config: programs: failing: {
+	command:      """
+		echo failed >> failing.txt
+		exit 1
+	"""
+	start_retries: 3
+	restart_pause: "1ms"
+	auto_restart: true
+}
+-- expect-failing.txt --
+failed
+failed
+failed

--- a/config/schema.cue
+++ b/config/schema.cue
@@ -8,7 +8,7 @@ import (
 // future-proofing
 version: "gopm.v1"
 runtime: #RuntimeConfig
-config: #Config
+config:  #Config
 
 // #Config defines the contents of the "config" value.
 #Config: {
@@ -37,7 +37,7 @@ config: #Config
 	filesystem: [string]: #File
 	filesystem: [name=_]: "name": name
 	filesystem: [_]: {
-		path: _
+		path:    _
 		absPath: pathpkg.Join([root, path], pathpkg.Unix)
 	}
 }
@@ -160,7 +160,7 @@ config: #Config
 }
 
 #File: {
-	name:    =~"^\\w+$"
+	name: =~"^\\w+$"
 	// path holds the path relative to the filesystem root.
 	path:    string & =~"."
 	content: string

--- a/process/manager.go
+++ b/process/manager.go
@@ -112,7 +112,7 @@ func (pm *Manager) StartAllProcesses() {
 	procs := pm.sendAll(processRequest{
 		kind: reqStart,
 	})
-	<-pm.notifier.watch(nil, procs, isReady)
+	<-pm.notifier.watch(nil, procs, isReadyOrFailed)
 }
 
 // StopProcesses starts all matching processes.
@@ -123,7 +123,7 @@ func (pm *Manager) StartProcesses(name string, labels map[string]string) error {
 	if len(procs) == 0 {
 		return ErrNotFound
 	}
-	<-pm.notifier.watch(nil, procs, isReady)
+	<-pm.notifier.watch(nil, procs, isReadyOrFailed)
 	return nil
 }
 

--- a/process/process.go
+++ b/process/process.go
@@ -221,9 +221,11 @@ func (p *process) run() {
 
 				// Wake up when the command has been running long enough
 				// to mark it as such.
+				p.startTime = time.Now()
+				p.stopTime = time.Time{}
 				timer.Reset(p.config.StartSeconds.D)
 			}
-			if time.Since(p.startTime) >= p.config.StartSeconds.D {
+			if p.cmd != nil && time.Since(p.startTime) >= p.config.StartSeconds.D {
 				// The command has been running for long enough to go
 				// into the Running state.
 				p.state = Running
@@ -314,6 +316,7 @@ func (p *process) run() {
 				} else {
 					p.state = Fatal
 				}
+				p.startCount = 0
 				break
 			}
 			// Wake up when we can try again.

--- a/process/watcher.go
+++ b/process/watcher.go
@@ -84,6 +84,10 @@ func isReady(s State) bool {
 	return s == Running || s == Exited
 }
 
+func isReadyOrFailed(s State) bool {
+	return s == Running || s == Exited || s == Fatal
+}
+
 func isStopped(s State) bool {
 	return s == Stopped
 }


### PR DESCRIPTION
This fixes two issues:
- the process code wasn't retting the retry count correctly.
- the `Manager.Start` method wasn't returning when a process being started had gone into the `Fatal` state.