### PR TITLE
feat: Add support to inject tag values when evaluating configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin/
 *.env
 etc/
 root/
+external/

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ bin/
 *.env
 etc/
 root/
-external/

--- a/cmd/gopm/main.go
+++ b/cmd/gopm/main.go
@@ -37,7 +37,7 @@ func init() {
 }
 
 func runServer() error {
-	s := gopm.NewSupervisor(rootOpt.Configuration, gopm.WithTags(rootOpt.Tags))
+	s := gopm.NewSupervisor(rootOpt.Configuration, rootOpt.Tags)
 	if err := s.Reload(); err != nil {
 		// Don't print configuration errors, as they've already been logged.
 		if errors.As(err, &gopm.SupervisorConfigError{}) {
@@ -106,7 +106,7 @@ func init() {
 
 func Main() int {
 	rootCmd.PersistentFlags().StringVarP(&rootOpt.Configuration, "config", "c", "", "Configuration directory")
-	rootCmd.PersistentFlags().StringArrayVarP(&rootOpt.Tags, "inject", "t", nil, "Set the value of a tagged field in the configuration")
+	rootCmd.PersistentFlags().StringArrayVarP(&rootOpt.Tags, "inject", "t", nil, "Set the value of a tagged field in the configuration (for example -t someField=someValue)")
 	flags := rootCmd.Flags()
 	flags.DurationVar(&rootOpt.QuitDelay, "quit-delay", 2*time.Second, "Time to wait for second CTRL-C before quitting. 0 to quit immediately.")
 	_ = rootCmd.MarkFlagRequired("config")

--- a/cmd/gopm/main.go
+++ b/cmd/gopm/main.go
@@ -37,7 +37,7 @@ func init() {
 }
 
 func runServer() error {
-	s := gopm.NewSupervisor(rootOpt.Configuration)
+	s := gopm.NewSupervisor(rootOpt.Configuration, gopm.WithTags(rootOpt.Tags))
 	if err := s.Reload(); err != nil {
 		// Don't print configuration errors, as they've already been logged.
 		if errors.As(err, &gopm.SupervisorConfigError{}) {
@@ -83,6 +83,7 @@ FOR:
 var (
 	rootOpt struct {
 		Configuration string
+		Tags          []string
 		EnvFile       string
 		QuitDelay     time.Duration
 	}
@@ -105,6 +106,7 @@ func init() {
 
 func Main() int {
 	rootCmd.PersistentFlags().StringVarP(&rootOpt.Configuration, "config", "c", "", "Configuration directory")
+	rootCmd.PersistentFlags().StringArrayVarP(&rootOpt.Tags, "inject", "t", nil, "Set the value of a tagged field in the configuration")
 	flags := rootCmd.Flags()
 	flags.DurationVar(&rootOpt.QuitDelay, "quit-delay", 2*time.Second, "Time to wait for second CTRL-C before quitting. 0 to quit immediately.")
 	_ = rootCmd.MarkFlagRequired("config")

--- a/cmd/gopm/script_test.go
+++ b/cmd/gopm/script_test.go
@@ -93,7 +93,6 @@ func signalNotifyCmd(cont bool, sigStr string, startFile, interruptedFile string
 			return nil
 		}
 	}
-	return nil
 }
 
 // waitfile waits until the argument file has been created.

--- a/cmd/gopm/testdata/config-dump-tags.txt
+++ b/cmd/gopm/testdata/config-dump-tags.txt
@@ -1,0 +1,65 @@
+mkdir progdir
+gopm -c gopmconfig --quit-delay 0 -t foo=one --inject bar=two &
+waitfile gopm.socket
+gopmctl --addr unix:gopm.socket dump-config
+cmpenv stdout expect-stdout
+
+-- gopmconfig/config.cue --
+package config
+
+config: grpc_server: {
+	network: "unix"
+	address: "gopm.socket"
+}
+config: programs: sleeper: {
+	command: """
+		echo hello foo=\(_foo) bar=\(_bar)
+		"""
+}
+_foo: *"aaa" | string @tag(foo,type=string)
+_bar: *"bbb" | string @tag(bar,type=string)
+-- expect-stdout --
+{
+	"root": "$WORK",
+	"environment": null,
+	"http_server": null,
+	"grpc_server": {
+		"address": "gopm.socket",
+		"network": "unix"
+	},
+	"programs": {
+		"sleeper": {
+			"name": "sleeper",
+			"directory": "$WORK",
+			"command": "echo hello foo=one bar=two",
+			"shell": "/bin/sh",
+			"environment": null,
+			"user": "",
+			"exit_codes": [
+				0,
+				2
+			],
+			"restart_pause": "0s",
+			"start_retries": 3,
+			"start_seconds": "1s",
+			"auto_start": true,
+			"auto_restart": false,
+			"restart_directory_monitor": "",
+			"restart_file_pattern": "*",
+			"stop_signals": [
+				"INT",
+				"KILL"
+			],
+			"stop_wait_seconds": "10s",
+			"stop_as_group": false,
+			"kill_as_group": false,
+			"logfile": "/dev/null",
+			"logfile_backups": 1,
+			"logfile_max_bytes": 52428800,
+			"logfile_max_backlog_bytes": 1048576,
+			"depends_on": null,
+			"labels": {}
+		}
+	},
+	"filesystem": {}
+}

--- a/cmd/gopmctl/gopmctlcmd/main.go
+++ b/cmd/gopmctl/gopmctlcmd/main.go
@@ -18,6 +18,7 @@ import (
 
 type Control struct {
 	Configuration string
+	Tags          []string
 	Address       string
 
 	client rpc.GopmClient
@@ -38,6 +39,7 @@ var (
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&control.Configuration, "config", "c", "", "Configuration file")
+	rootCmd.PersistentFlags().StringArrayVarP(&control.Tags, "inject", "t", nil, "Set the value of a tagged field in the configuration (for example -t someField=someValue)")
 	rootCmd.PersistentFlags().StringVar(&control.Address, "addr", "localhost:9002", "gopm server address")
 	rootCmd.AddCommand(&dumpConfigCmd)
 	rootCmd.AddCommand(&reloadCmd)
@@ -74,7 +76,7 @@ func (ctl *Control) getServerURL() string {
 	if ctl.Address != "" {
 		return ctl.Address
 	} else if _, err := os.Stat(ctl.Configuration); err == nil {
-		cfg, err := config.Load(ctl.Configuration)
+		cfg, err := config.Load(ctl.Configuration, nil)
 		if err == nil {
 			// TODO return error from getServerURL
 			svr := cfg.GRPCServer

--- a/config/config.go
+++ b/config/config.go
@@ -25,24 +25,11 @@ var (
 	pathConfig       = cue.MakePath(cue.Str("config"))
 )
 
-type options struct {
-	tags []string
-}
-
-type optionFunc func(o *options)
-
-// WithTags returns an option function to provide a list of tag values when loading the configuration.
-func WithTags(tags []string) optionFunc {
-	return func(o *options) {
-		o.tags = tags
-	}
-}
-
-// Load loads the configuration at the given directory, using the specified options, and returns it.
+// Load loads the configuration at the given directory, with any configuration tags, and returns it.
 // On error, the error value may contain an Error value
 // containing multiple errors.
-func Load(configDir string, opts ...optionFunc) (*Config, error) {
-	cfg, err := load0(configDir, opts...)
+func Load(configDir string, tags []string) (*Config, error) {
+	cfg, err := load0(configDir, tags)
 	if err == nil {
 		return cfg, nil
 	}
@@ -54,12 +41,7 @@ func Load(configDir string, opts ...optionFunc) (*Config, error) {
 	return nil, err
 }
 
-func load0(configDir string, opts ...optionFunc) (*Config, error) {
-	var o options
-	for _, opt := range opts {
-		opt(&o)
-	}
-
+func load0(configDir string, tags []string) (*Config, error) {
 	info, err := os.Stat(configDir)
 	if err != nil {
 		return nil, err
@@ -91,7 +73,7 @@ func load0(configDir string, opts ...optionFunc) (*Config, error) {
 	ctx := cuecontext.New()
 	insts := load.Instances([]string{"."}, &load.Config{
 		Dir:  configDir,
-		Tags: o.tags,
+		Tags: tags,
 	})
 	for _, inst := range insts {
 		if err := inst.Err; err != nil {

--- a/config/schema.cue
+++ b/config/schema.cue
@@ -8,7 +8,7 @@ import (
 // future-proofing
 version: "gopm.v1"
 runtime: #RuntimeConfig
-config: #Config
+config:  #Config
 
 // #Config defines the contents of the "config" value.
 #Config: {
@@ -37,7 +37,7 @@ config: #Config
 	filesystem: [string]: #File
 	filesystem: [name=_]: "name": name
 	filesystem: [_]: {
-		path: _
+		path:    _
 		absPath: pathpkg.Join([root, path], pathpkg.Unix)
 	}
 }
@@ -87,7 +87,7 @@ config: #Config
 	// labels is
 	labels: [string]: string
 	environment?: {
-		{[=~"^\\w+$"]: string}
+		{[string]: string}
 	}
 	// user holds the username to run the process as.
 	user?: string
@@ -160,7 +160,7 @@ config: #Config
 }
 
 #File: {
-	name:    =~"^\\w+$"
+	name: =~"^\\w+$"
 	// path holds the path relative to the filesystem root.
 	path:    string & =~"."
 	content: string
@@ -171,8 +171,6 @@ config: #Config
 }
 
 #WithDefaults: {
-	...
-
 	runtime: #RuntimeConfig
 
 	config: #Config
@@ -193,4 +191,6 @@ config: #Config
 		logfile_max_bytes:         *50Mi | _
 		logfile_max_backlog_bytes: *1Mi | _
 	}
+
+	...
 }

--- a/supervisor.go
+++ b/supervisor.go
@@ -38,26 +38,14 @@ type Supervisor struct {
 	done       chan struct{}
 }
 
-type optionFunc func(s *Supervisor)
-
-// WithTags returns an option function to configure a Supervisor
-// with a list of tag values to use when evaluating the configuration.
-func WithTags(tags []string) optionFunc {
-	return func(s *Supervisor) {
-		s.tags = tags
-	}
-}
-
-// NewSupervisor create a Supervisor object with supervisor configuration file, using the specified options.
-func NewSupervisor(configFile string, opts ...optionFunc) *Supervisor {
+// NewSupervisor create a Supervisor object with supervisor configuration file and configuration tags.
+func NewSupervisor(configFile string, tags []string) *Supervisor {
 	s := &Supervisor{
 		configFile: configFile,
+		tags:       tags,
 		procMgr:    process.NewManager(),
 		config:     new(config.Config),
 		done:       make(chan struct{}),
-	}
-	for _, opt := range opts {
-		opt(s)
 	}
 	return s
 }
@@ -93,7 +81,7 @@ func (s *Supervisor) Done() <-chan struct{} {
 // Reload reloads the supervisor configuration
 func (s *Supervisor) Reload() error {
 	zap.L().Info("reloading configuration")
-	newConfig, err := config.Load(s.configFile, config.WithTags(s.tags))
+	newConfig, err := config.Load(s.configFile, s.tags)
 	if err != nil {
 		zap.L().Error("Error loading configuration", zap.Error(err))
 		var configErr *config.ConfigError

--- a/supervisor.go
+++ b/supervisor.go
@@ -40,14 +40,13 @@ type Supervisor struct {
 
 // NewSupervisor create a Supervisor object with supervisor configuration file and configuration tags.
 func NewSupervisor(configFile string, tags []string) *Supervisor {
-	s := &Supervisor{
+	return &Supervisor{
 		configFile: configFile,
 		tags:       tags,
 		procMgr:    process.NewManager(),
 		config:     new(config.Config),
 		done:       make(chan struct{}),
 	}
-	return s
 }
 
 // Close closes the server, stopping all processes gracefully.


### PR DESCRIPTION
It is useful to support cue `@tag` directives in order to override certain configuration values at runtime without having to modify existing `.cue` files. Tags are specified when invoking `gopm` either with `--inject` or `-t`, which is the same syntax is `cue eval`.

Signed-off-by: Stuart Carnie <stuart.carnie@gmail.com>