### PR TITLE
feat: restart dependencies on update if they were already running

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,8 @@
 ## core
 
-- [ ] respect topological order when stopping processes on request
+- [x] respect topological order when starting and stopping processes on request
 - [x] allow empty commands
-- [ ] oneshot attribute
+- [x] oneshot attribute
 - [ ] file tree watching
 - [ ] add `-a` (`--all`) flag to `gopmctl logs` command to print all the available logs for a process
 - [x] implement process signaling

--- a/cmd/gopm/testdata/dependencies.txt
+++ b/cmd/gopm/testdata/dependencies.txt
@@ -1,47 +1,101 @@
-# Test that programs are started in reverse-dependency order.
+# Test that programs are started and stopped in dependency order.
+cp generation0.txt generation.txt
+
 gopm -c gopmconfig --quit-delay 0 &
+waitfile  gopm.socket
+
+# Test that everything starts up OK.
 waitfile a.txt
-cmp a.txt expect-a.txt
+cmp a.txt expect-a0.txt
+
+# Adjust the configuration a bit and reload, which changes c,
+# so only c and programs that depend on it should be reloaded.
+# Update the generation file first so that we can see which
+# ones have re-run.
+cp generation1.txt generation.txt
+rm a.txt
+appendfile gopmconfig/config.cue extra-config.cue
+gopmctl --addr unix:gopm.socket reload
+waitfile a.txt
+cmp a.txt expect-a1.txt
+! exists stop-failures.txt
+
+# Shut everything down, which should shut all programs
+# down in dependency order.
 gopmctl --addr unix:gopm.socket shutdown
 wait
+! exists stop-failures.txt
+! exists a.txt
+! exists b.txt
+! exists c.txt
+! exists d.txt
+
+-- expect-a0.txt --
+a0 [ b0 [ c0 [ d0 ] ] [ d0 ] ] [ c0 [ d0 ] ]
+-- expect-a1.txt --
+a1 [ b1 [ c1 [ d0 ] ] [ d0 ] ] [ c1 [ d0 ] ]
+-- generation0.txt --
+0
+-- generation1.txt --
+1
+-- extra-config.cue --
+
+// This won't have any effect on how the program runs,
+// but should cause it to restart, thus triggering restarts
+// of the programs that depend on it.
+config: programs: c: start_retries: 10
 
 -- gopmconfig/config.cue --
 package config
+import "strings"
+
+#Prog: {
+	name: _
+	depends_on: [... string]
+	// Example command:
+	// 	sleep 0.5
+	//	echo "a [ $(cat b.txt) ] [ $(cat c.txt) ] > a.txt
+	command: """
+		sleep 0.25
+		echo "\(name)$(cat generation.txt)\(strings.Join([
+			for dep in depends_on {
+				" [ $(cat \(dep).txt) ]"
+			},
+		], ""))" > \(name).txt
+
+		# Make sure the script itself continues when the sleep is killed.
+		trap " " INT
+
+		# Wait until we're interrupted
+		sleep 20
+
+		# When we're interrupted, remove our own file. The files
+		# of our dependencies should still be there.
+		rm \(name).txt
+		for dep in \(strings.Join(depends_on, " ")); do
+			if ! test -f $dep.txt; then
+				echo \(name): dependency $dep removed too early >> stop-failures.txt
+			fi
+		done
+
+		# Wait a little bit to make sure that the stop logic really is waiting correctly.
+		sleep 0.25
+
+	"""
+	start_seconds: "1s"
+	...
+}
 
 config: {
 	grpc_server: {
 		network: "unix"
 		address: "gopm.socket"
 	}
-	programs: [_]: start_seconds: "1s"
+	programs: [_]: #Prog
 	programs: {
-		a: {
-			command: """
-				echo "a [ $(cat b.txt) ] [ $(cat c.txt) ]" > a.txt
-				"""
-			depends_on: ["b", "c"]
-		}
-		b: {
-			command: """
-				sleep 0.5
-				echo "b [ $(cat c.txt) ] [ $(cat d.txt) ]" > b.txt
-				"""
-			depends_on: ["c", "d"]
-		}
-		c: {
-			command: """
-				sleep 0.5
-				echo "c [ $(cat d.txt) ]" > c.txt
-				"""
-			depends_on: ["d"]
-		}
-		d: {
-			command: """
-				sleep 0.5
-				echo d > d.txt
-				"""
-		}
+		a: depends_on: ["b", "c"]
+		b: depends_on: ["c", "d"]
+		c: depends_on: ["d"]
+		d: {}
 	}
 }
--- expect-a.txt --
-a [ b [ c [ d ] ] [ d ] ] [ c [ d ] ]

--- a/cmd/gopm/testdata/dependencies.txt
+++ b/cmd/gopm/testdata/dependencies.txt
@@ -20,6 +20,19 @@ waitfile a.txt
 cmp a.txt expect-a1.txt
 ! exists stop-failures.txt
 
+# Stop b only, which should stop a, which depends on it.
+gopmctl --addr unix:gopm.socket stop b
+! exists stop-failures.txt
+! exists a.txt
+! exists b.txt
+exists c.txt
+exists d.txt
+
+# Start a, which should start a too.
+cp generation2.txt generation.txt
+gopmctl --addr unix:gopm.socket start a
+cmp a.txt expect-a2.txt
+
 # Shut everything down, which should shut all programs
 # down in dependency order.
 gopmctl --addr unix:gopm.socket shutdown
@@ -34,10 +47,14 @@ wait
 a0 [ b0 [ c0 [ d0 ] ] [ d0 ] ] [ c0 [ d0 ] ]
 -- expect-a1.txt --
 a1 [ b1 [ c1 [ d0 ] ] [ d0 ] ] [ c1 [ d0 ] ]
+-- expect-a2.txt --
+a2 [ b2 [ c1 [ d0 ] ] [ d0 ] ] [ c1 [ d0 ] ]
 -- generation0.txt --
 0
 -- generation1.txt --
 1
+-- generation2.txt --
+2
 -- extra-config.cue --
 
 // This won't have any effect on how the program runs,

--- a/process/manager.go
+++ b/process/manager.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/stuartcarnie/gopm/config"
 	"github.com/stuartcarnie/gopm/logger"
 	"github.com/stuartcarnie/gopm/rpc"
@@ -66,6 +68,7 @@ type ProcessInfo struct {
 
 // AllProcessInfo returns information on all the processes.
 func (pm *Manager) AllProcessInfo() []*ProcessInfo {
+	zap.L().Debug("Manager.AllProcessInfo")
 	reply := make(chan *ProcessInfo)
 	n := len(pm.sendAll(processRequest{
 		kind:      reqInfo,
@@ -84,6 +87,7 @@ func (pm *Manager) AllProcessInfo() []*ProcessInfo {
 // RestartProcesses restarts all matching processes. If some failed to restart, it
 // returns an *rpc.NotStartedError describing the processes that didn't.
 func (pm *Manager) RestartProcesses(name string, labels map[string]string) error {
+	zap.L().Debug("Manager.RestartProcesses")
 	procs := pm.send(processRequest{
 		kind: reqRestart,
 	}, name, labels)
@@ -96,6 +100,7 @@ func (pm *Manager) RestartProcesses(name string, labels map[string]string) error
 
 // SignalProcesses sends the given signal to all matching processes.
 func (pm *Manager) SignalProcesses(name string, labels map[string]string, sig config.Signal) error {
+	zap.L().Debug("Manager.SignalProcesses")
 	procs := pm.send(processRequest{
 		kind:   reqSignal,
 		signal: sig,
@@ -112,6 +117,7 @@ func (pm *Manager) SignalProcesses(name string, labels map[string]string, sig co
 // StartAllProcesses starts all the processes. If some failed to start, it
 // returns an *rpc.NotStartedError describing the processes that didn't.
 func (pm *Manager) StartAllProcesses() error {
+	zap.L().Debug("Manager.StartAllProcesses")
 	procs := pm.sendAll(processRequest{
 		kind: reqStart,
 	})
@@ -122,6 +128,7 @@ func (pm *Manager) StartAllProcesses() error {
 // StartProcesses starts all matching processes. If some failed to start, it
 // returns an *rpc.NotStartedError describing the processes that didn't.
 func (pm *Manager) StartProcesses(name string, labels map[string]string) error {
+	zap.L().Debug("Manager.StartProcesses")
 	procs := pm.send(processRequest{
 		kind: reqStart,
 	}, name, labels)
@@ -134,6 +141,7 @@ func (pm *Manager) StartProcesses(name string, labels map[string]string) error {
 
 // StopAllProcesses stops all the processes managed by this manager
 func (pm *Manager) StopAllProcesses() {
+	zap.L().Debug("Manager.StopAllProcesses")
 	procs := pm.sendAll(processRequest{
 		kind: reqStop,
 	})
@@ -142,6 +150,7 @@ func (pm *Manager) StopAllProcesses() {
 
 // StopProcesses stops all matching processes.
 func (pm *Manager) StopProcesses(name string, labels map[string]string) error {
+	zap.L().Debug("Manager.StopProcesses")
 	procs := pm.send(processRequest{
 		kind: reqStop,
 	}, name, labels)


### PR DESCRIPTION
This change means that if a dependency is changed by an update
and it wasn't explicitly stopped, that it will be restarted after its configuration
has been updated.

It also significantly improves the dependency tests so that we test the
previously implemented but untested behaviour that
when a program is changed, all the programs that depend on it will
be stopped too. We also fix the `walkChanged` logic that was causing
this functionality to not work previously.

Also (in a separate commit): start and stop dependencies as well as explicitly mentioned processes
    
This changes the behaviour of `gopmctl stop` so that it will also stop and processes that depend on the processes being stopped, and the behaviour of `gopmctl start` so that it will start any dependencies too.