### PR TITLE
process: avoid the possibility of some commands hanging indefinitely

### DIFF
--- a/cmd/gopm/testdata/start-during-reload.txt
+++ b/cmd/gopm/testdata/start-during-reload.txt
@@ -1,0 +1,47 @@
+gopm -c gopmconfig --quit-delay 0 &
+
+waitfile started.txt
+
+# reload a new version of the configuration, which should interrupt
+# the program, then wait for stop_wait_seconds, then
+# kill it properly.
+# However, in the meantime, we'll start the process,
+# which will move the status back to Started and abort
+# the reload.
+cp config2.cue gopmconfig/config.cue
+! gopmctl --addr unix:gopm.socket reload &reload&
+waitfile intr.txt
+
+gopmctl --addr unix:gopm.socket start prog
+
+wait reload
+stderr 'Error: rpc error: cannot stop processes: some processes were started unexpectedly after asking them to stop \(prog\)'
+
+-- gopmconfig/config.cue --
+package config
+
+config: grpc_server: {
+	network: "unix"
+	address: "gopm.socket"
+}
+config: programs: prog: {
+	command: """
+		trap ":" INT
+		interrupt-notify started.txt intr.txt
+		sleep 15
+		"""
+	stop_wait_seconds: "1s"
+}
+-- config2.cue --
+package config
+
+config: grpc_server: {
+	network: "unix"
+	address: "gopm.socket"
+}
+config: programs: prog: {
+	command: """
+		echo > started2.txt
+		"""
+	stop_wait_seconds: "1s"
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/rogpeppe/go-internal v1.8.1-0.20211205105603-854826fb81fa
+	github.com/rogpeppe/go-internal v1.8.2-0.20220112175052-f3cb5c2c6412
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/zap v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
-github.com/rogpeppe/go-internal v1.8.1-0.20211205105603-854826fb81fa h1:56yZOl+mavzzoiGjlVzboPZVVz8CjLHZz+Ip5IWxcA4=
-github.com/rogpeppe/go-internal v1.8.1-0.20211205105603-854826fb81fa/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
+github.com/rogpeppe/go-internal v1.8.2-0.20220112175052-f3cb5c2c6412 h1:BVgfta5l+NeAx6l597tEbF2TkiVi+Mw+2vxJjwSfyRU=
+github.com/rogpeppe/go-internal v1.8.2-0.20220112175052-f3cb5c2c6412/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/supervisor.go
+++ b/supervisor.go
@@ -121,7 +121,9 @@ func (s *Supervisor) Reload() error {
 	s.startGrpcServer(newConfig, gRPCListener)
 
 	s.createFiles(newConfig)
-	s.procMgr.Update(context.TODO(), newConfig)
+	if err := s.procMgr.Update(context.TODO(), newConfig); err != nil {
+		return err
+	}
 	s.config = newConfig
 
 	return nil


### PR DESCRIPTION
Currently, if we're trying to stop or start processes and waiting for them
to become stopped or running, that wait will wait indefinitely if
some concurrent command starts or stops one of the processes while
we're waiting, because the wait waits only for the expected state.

Fix this by always waiting for a steady state (e.g. Running, Stopped, Fatal),
and then checking that the steady state is the one that we're expecting.
We avoid a race condition by adding a reply channel to the request
that allows the process to notify the caller when its state has been
initially updated in response to the request.