### PR TITLE
config: use map for depends_on, not slice

### DIFF
--- a/cmd/gopm/testdata/cyclic-depends.txt
+++ b/cmd/gopm/testdata/cyclic-depends.txt
@@ -15,11 +15,13 @@ config: grpc_server: {
 config: programs: {
 	a: {
 		command: " "
-		depends_on: ["b", "c"]
+		depends_on: b: true
+		depends_on: c: true
 	}
 	b: {
 		command: " "
-		depends_on: ["d", "a"]
+		depends_on: d: true
+		depends_on: a: true
 	}
 	c: {
 		command: " "

--- a/cmd/gopm/testdata/dependencies.txt
+++ b/cmd/gopm/testdata/dependencies.txt
@@ -102,7 +102,7 @@ import "strings"
 
 #Prog: {
 	name: _
-	depends_on: [... string]
+	depends_on: [string]: true
 	// Example command:
 	// 	sleep 0.5
 	//	echo "a [ $(cat b.txt) ] [ $(cat c.txt) ] > a.txt
@@ -110,7 +110,7 @@ import "strings"
 		echo --- \(name) running
 		sleep 0.25
 		echo "\(name)$(cat generation.txt)\(strings.Join([
-			for dep in depends_on {
+			for dep, _ in depends_on {
 				" [ $(cat \(dep).txt) ]"
 			},
 		], ""))" > \(name).txt
@@ -128,7 +128,7 @@ import "strings"
 		# When we're interrupted, remove our own file. The files
 		# of our dependencies should still be there.
 		rm -f \(name).txt
-		for dep in \(strings.Join(depends_on, " ")); do
+		for dep in \(strings.Join([for dep, _ in depends_on {dep}], " ")); do
 			if ! test -f $dep.txt; then
 				echo \(name): dependency $dep removed too early >> stop-failures.txt
 			fi
@@ -150,9 +150,15 @@ config: {
 	}
 	programs: [_]: #Prog
 	programs: {
-		a: depends_on: ["b", "c"]
-		b: depends_on: ["c", "d"]
-		c: depends_on: ["d"]
+		a: depends_on: {
+			b: true,
+			c: true,
+		}
+		b: depends_on:  {
+			c: true,
+			d: true,
+		}
+		c: depends_on: d: true
 		d: {}
 	}
 }

--- a/cmd/gopm/testdata/empty-command.txt
+++ b/cmd/gopm/testdata/empty-command.txt
@@ -18,11 +18,12 @@ config: {
 			command: """
 				echo "a [ $(cat b.txt) ] [ $(cat c.txt) ]" > a.txt
 				"""
-			depends_on: ["pseudo"]
+			depends_on: pseudo: true
 		}
 		pseudo: {
 			command: ""
-			depends_on: ["b", "c"]
+			depends_on: b: true
+			depends_on: c: true
 		}
 		b: {
 			command: """

--- a/cmd/gopm/testdata/non-existent-depends.txt
+++ b/cmd/gopm/testdata/non-existent-depends.txt
@@ -15,6 +15,6 @@ config: grpc_server: {
 config: programs: {
 	a: {
 		command: " "
-		depends_on: ["b"]
+		depends_on: b: true
 	}
 }

--- a/cmd/gopm/testdata/status.txt
+++ b/cmd/gopm/testdata/status.txt
@@ -19,7 +19,7 @@ config: grpc_server: {
 config: programs: {
 	hello: {
 		command: "echo hello"
-		depends_on: ["foo"]
+		depends_on: foo: true
 	}
 	foo: {
 		command: "sleep 10"

--- a/config/config.go
+++ b/config/config.go
@@ -207,7 +207,7 @@ func (cfg *Config) verifyDependencies() error {
 
 func (cfg *Config) checkDepsExist() error {
 	for _, p := range cfg.Programs {
-		for _, dep := range p.DependsOn {
+		for dep := range p.DependsOn {
 			if cfg.Programs[dep] == nil {
 				return fmt.Errorf("program %q has dependency on non-existent program %q", p.Name, dep)
 			}
@@ -304,7 +304,7 @@ type Program struct {
 	LogFileBackups          int               `json:"logfile_backups"`
 	LogFileMaxBytes         int64             `json:"logfile_max_bytes"`
 	LogFileMaxBacklogBytes  int               `json:"logfile_max_backlog_bytes"`
-	DependsOn               []string          `json:"depends_on"`
+	DependsOn               map[string]bool   `json:"depends_on"`
 	Labels                  map[string]string `json:"labels"`
 }
 

--- a/config/schema.cue
+++ b/config/schema.cue
@@ -86,15 +86,20 @@ config:  #Config
 	// above command. The shell is invoked as $shell -c $command.
 	shell?: string
 
-	// A list of process names that must be started before starting
-	// this process.
-	depends_on?: [...string]
+	// depends_on holds set of process names that must be started before starting
+	// this process. Each key in the map must name another program.
+	// Cyclic dependencies are not allowed.
+	depends_on?: [string]: true
 
-	// labels is
+	// labels holds a set of labels to associate with the program.
+	// Some gopmctl commands can be applied to all programs with
+	// a matching set of labels.
 	labels: [string]: string
-	environment?: {
-		{[string]: string}
-	}
+
+	// environment holds the environment variables to pass to the program.
+	// Note that this is empty by default.
+	environment?: [string]: string
+
 	// user holds the username to run the process as.
 	user?: string
 
@@ -140,11 +145,6 @@ config:  #Config
 
 	// stop_wait_seconds holds the time to wait for the process to stop after sending a signal.
 	stop_wait_seconds?: time.Duration
-
-	// A list of process names that must be started before starting
-	// this process
-	depends_on?: [...string]
-	labels: [string]: string
 
 	// logfile holds the file to write the output of the process to. If this is /dev/stderr
 	// or /dev/stdout, the output will be written to gopm's standard error or standard

--- a/config/topo_test.go
+++ b/config/topo_test.go
@@ -55,14 +55,18 @@ func TestVerifyDependencies(t *testing.T) {
 				Programs: make(map[string]*Program),
 			}
 			for name, deps := range test.deps {
+				depsMap := make(map[string]bool)
+				for _, dep := range deps {
+					depsMap[dep] = true
+				}
 				p := cfg.Programs[name]
 				if p == nil {
 					cfg.Programs[name] = &Program{
 						Name:      name,
-						DependsOn: deps,
+						DependsOn: depsMap,
 					}
 				} else {
-					p.DependsOn = deps
+					p.DependsOn = depsMap
 				}
 				// Make sure all the dependencies have nodes too,
 				// so we don't have to specify terminal nodes in each test.

--- a/config/toposort.go
+++ b/config/toposort.go
@@ -30,7 +30,7 @@ func topoSort(programs map[string]*Program) (sorted []string, cycles [][]string)
 
 // dependsOn reports whether p depends on any member of others.
 func (cfg *Config) dependsOn(p *Program, others map[*Program]bool) bool {
-	for _, dep := range p.DependsOn {
+	for dep := range p.DependsOn {
 		if others[cfg.Programs[dep]] || cfg.dependsOn(cfg.Programs[dep], others) {
 			return true
 		}
@@ -62,7 +62,7 @@ func (v *visitor) visit(n string) (cycles [][]string) {
 		return [][]string{{n}}
 	}
 	v.visiting[n] = true
-	for _, child := range v.programs[n].DependsOn {
+	for child := range v.programs[n].DependsOn {
 		cycles = append(cycles, v.visit(child)...)
 	}
 	v.done[n] = true

--- a/process/update.go
+++ b/process/update.go
@@ -127,7 +127,7 @@ func (pm *Manager) markReady(p *process, ready map[*process]bool, state map[stri
 		return pDepsReady && isReady(state[p.name])
 	}
 	pDepsReady = true
-	for _, dep := range pm.config.Programs[p.name].DependsOn {
+	for dep := range pm.config.Programs[p.name].DependsOn {
 		p := pm.processes[dep]
 		if p == nil {
 			pDepsReady = false
@@ -314,7 +314,7 @@ func walkDeps(cfg *config.Config, p *config.Program, isTarget func(*config.Progr
 		isChild = true
 	}
 	isParent := false
-	for _, name := range p.DependsOn {
+	for name := range p.DependsOn {
 		isParent = walkDeps(cfg, cfg.Programs[name], isTarget, isChild, deps) || isParent
 	}
 	if isParent {


### PR DESCRIPTION
`[string]: true` is a much more natural representation of a set in CUE, and makes
it easy to add dependencies in an orthogonal manner because `a: true` unifies
with `b: true`, whereas `["a"]` does not unify with `["b"]`.

This is arguably a slight syntactic inconvenience, but I think it's worth doing.

Note: this is a backwardly incompatible change.