### PR TITLE
feat: Add path option to specify additional CUE files

### DIFF
--- a/cmd/gopm/main.go
+++ b/cmd/gopm/main.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 func runServer() error {
-	s := gopm.NewSupervisor(rootOpt.Configuration, rootOpt.Tags)
+	s := gopm.NewSupervisor(rootOpt.Configuration, rootOpt.Tags, rootOpt.CueFiles)
 	if err := s.Reload(); err != nil {
 		// Don't print configuration errors, as they've already been logged.
 		if errors.As(err, &gopm.SupervisorConfigError{}) {
@@ -87,6 +87,7 @@ var (
 		Tags          []string
 		EnvFile       string
 		QuitDelay     time.Duration
+		CueFiles      []string
 	}
 
 	rootCmd = cobra.Command{
@@ -95,6 +96,7 @@ var (
 			cmd.SilenceUsage = true
 			return nil
 		},
+		Args: cobra.NoArgs,
 	}
 )
 
@@ -108,6 +110,7 @@ func init() {
 func Main() int {
 	rootCmd.PersistentFlags().StringVarP(&rootOpt.Configuration, "config", "c", "", "Configuration directory")
 	rootCmd.PersistentFlags().StringArrayVarP(&rootOpt.Tags, "inject", "t", nil, "Set the value of a tagged field in the configuration (for example -t someField=someValue)")
+	rootCmd.PersistentFlags().StringArrayVarP(&rootOpt.CueFiles, "cue", "p", nil, "Paths to load additional CUE files")
 	flags := rootCmd.Flags()
 	flags.DurationVar(&rootOpt.QuitDelay, "quit-delay", 2*time.Second, "Time to wait for second CTRL-C before quitting. 0 to quit immediately.")
 	_ = rootCmd.MarkFlagRequired("config")

--- a/cmd/gopm/main.go
+++ b/cmd/gopm/main.go
@@ -110,7 +110,7 @@ func init() {
 func Main() int {
 	rootCmd.PersistentFlags().StringVarP(&rootOpt.Configuration, "config", "c", "", "Configuration directory")
 	rootCmd.PersistentFlags().StringArrayVarP(&rootOpt.Tags, "inject", "t", nil, "Set the value of a tagged field in the configuration (for example -t someField=someValue)")
-	rootCmd.PersistentFlags().StringArrayVarP(&rootOpt.CueFiles, "cue", "p", nil, "Paths to load additional CUE files")
+	rootCmd.PersistentFlags().StringArrayVarP(&rootOpt.CueFiles, "include", "i", nil, "Include additional CUE configuration file(s). (-i FILE [-i FILE])")
 	flags := rootCmd.Flags()
 	flags.DurationVar(&rootOpt.QuitDelay, "quit-delay", 2*time.Second, "Time to wait for second CTRL-C before quitting. 0 to quit immediately.")
 	_ = rootCmd.MarkFlagRequired("config")

--- a/cmd/gopm/testdata/config-dump-paths.txt
+++ b/cmd/gopm/testdata/config-dump-paths.txt
@@ -1,5 +1,5 @@
 mkdir progdir
-gopm -c gopmconfig --quit-delay 0 -p gopmextra/options.cue &
+gopm -c gopmconfig --quit-delay 0 -i gopmextra/options.cue &
 waitfile gopm.socket
 gopmctl --addr unix:gopm.socket dump-config
 cmpenv stdout expect-stdout
@@ -12,8 +12,6 @@ config: grpc_server: {
 	address: "gopm.socket"
 }
 -- gopmextra/options.cue --
-package config
-
 config: programs: sleeper: {
 	command: """
 		echo hello

--- a/cmd/gopm/testdata/config-dump-paths.txt
+++ b/cmd/gopm/testdata/config-dump-paths.txt
@@ -1,0 +1,67 @@
+mkdir progdir
+gopm -c gopmconfig --quit-delay 0 -p gopmextra/options.cue &
+waitfile gopm.socket
+gopmctl --addr unix:gopm.socket dump-config
+cmpenv stdout expect-stdout
+
+-- gopmconfig/config.cue --
+package config
+
+config: grpc_server: {
+	network: "unix"
+	address: "gopm.socket"
+}
+-- gopmextra/options.cue --
+package config
+
+config: programs: sleeper: {
+	command: """
+		echo hello
+		"""
+}
+-- expect-stdout --
+{
+	"root": "$WORK",
+	"environment": null,
+	"http_server": null,
+	"grpc_server": {
+		"address": "gopm.socket",
+		"network": "unix"
+	},
+	"programs": {
+		"sleeper": {
+			"name": "sleeper",
+			"directory": "$WORK",
+			"command": "echo hello",
+			"shell": "/bin/sh",
+			"environment": null,
+			"user": "",
+			"exit_codes": [
+				0,
+				2
+			],
+			"restart_pause": "0s",
+			"start_retries": 3,
+			"oneshot": false,
+			"start_seconds": "1s",
+			"auto_start": true,
+			"auto_restart": false,
+			"restart_directory_monitor": "",
+			"restart_file_pattern": "*",
+			"stop_signals": [
+				"INT",
+				"KILL"
+			],
+			"stop_wait_seconds": "10s",
+			"stop_as_group": false,
+			"kill_as_group": false,
+			"logfile": "/dev/null",
+			"logfile_backups": 1,
+			"logfile_max_bytes": 52428800,
+			"logfile_max_backlog_bytes": 1048576,
+			"depends_on": null,
+			"labels": {}
+		}
+	},
+	"filesystem": {}
+}

--- a/cmd/gopm/testdata/gopm-path-invalid-cue.txt
+++ b/cmd/gopm/testdata/gopm-path-invalid-cue.txt
@@ -1,0 +1,13 @@
+! gopm -c gopmconfig --quit-delay 0 -p gopmextra/options.cue
+stderr 'error:cannot parse CUE file "gopmextra/options.cue":.*'
+
+-- gopmconfig/config.cue --
+package config
+
+config: grpc_server: {
+	network: "unix"
+	address: "gopm.socket"
+}
+
+-- gopmextra/options.cue --
+not valid cue

--- a/cmd/gopm/testdata/gopm-path-invalid-cue.txt
+++ b/cmd/gopm/testdata/gopm-path-invalid-cue.txt
@@ -1,4 +1,4 @@
-! gopm -c gopmconfig --quit-delay 0 -p gopmextra/options.cue
+! gopm -c gopmconfig --quit-delay 0 --include gopmextra/options.cue
 stderr 'error:cannot parse CUE file "gopmextra/options.cue":.*'
 
 -- gopmconfig/config.cue --

--- a/cmd/gopm/testdata/gopm-path-is-dir.txt
+++ b/cmd/gopm/testdata/gopm-path-is-dir.txt
@@ -1,5 +1,5 @@
-! gopm -c gopmconfig --quit-delay 0 -p gopmextra
-stderr 'error:CUE path must be a file, found directory "gopmextra"'
+! gopm -c gopmconfig --quit-delay 0 -i gopmextra
+stderr 'error:cannot read CUE path: read gopmextra: is a directory'
 
 -- gopmconfig/config.cue --
 package config
@@ -10,8 +10,6 @@ config: grpc_server: {
 }
 
 -- gopmextra/options.cue --
-package config
-
 config: programs: sleeper: {
 	command: """
 		echo hello

--- a/cmd/gopm/testdata/gopm-path-is-dir.txt
+++ b/cmd/gopm/testdata/gopm-path-is-dir.txt
@@ -1,0 +1,19 @@
+! gopm -c gopmconfig --quit-delay 0 -p gopmextra
+stderr 'error:CUE path must be a file, found directory "gopmextra"'
+
+-- gopmconfig/config.cue --
+package config
+
+config: grpc_server: {
+	network: "unix"
+	address: "gopm.socket"
+}
+
+-- gopmextra/options.cue --
+package config
+
+config: programs: sleeper: {
+	command: """
+		echo hello
+		"""
+}

--- a/cmd/gopm/testdata/gopm-path-is-dir.txt
+++ b/cmd/gopm/testdata/gopm-path-is-dir.txt
@@ -1,5 +1,5 @@
 ! gopm -c gopmconfig --quit-delay 0 -i gopmextra
-stderr 'error:cannot read CUE path: read gopmextra: is a directory'
+stderr 'error:cannot read CUE file: read gopmextra: is a directory'
 
 -- gopmconfig/config.cue --
 package config

--- a/cmd/gopm/testdata/gopm-path-not-exists.txt
+++ b/cmd/gopm/testdata/gopm-path-not-exists.txt
@@ -1,5 +1,5 @@
 ! gopm -c gopmconfig --quit-delay 0 -i gopmextra/foo.cue
-stderr 'error:cannot read CUE path: open gopmextra/foo.cue: no such file or directory'
+stderr 'error:cannot read CUE file: open gopmextra/foo.cue: no such file or directory'
 
 -- gopmconfig/config.cue --
 package config

--- a/cmd/gopm/testdata/gopm-path-not-exists.txt
+++ b/cmd/gopm/testdata/gopm-path-not-exists.txt
@@ -1,0 +1,19 @@
+! gopm -c gopmconfig --quit-delay 0 -p gopmextra/foo.cue
+stderr 'error:cannot load CUE path "gopmextra/foo.cue": path does not exist'
+
+-- gopmconfig/config.cue --
+package config
+
+config: grpc_server: {
+	network: "unix"
+	address: "gopm.socket"
+}
+
+-- gopmextra/options.cue --
+package config
+
+config: programs: sleeper: {
+	command: """
+		echo hello
+		"""
+}

--- a/cmd/gopm/testdata/gopm-path-not-exists.txt
+++ b/cmd/gopm/testdata/gopm-path-not-exists.txt
@@ -1,5 +1,5 @@
-! gopm -c gopmconfig --quit-delay 0 -p gopmextra/foo.cue
-stderr 'error:cannot load CUE path "gopmextra/foo.cue": path does not exist'
+! gopm -c gopmconfig --quit-delay 0 -i gopmextra/foo.cue
+stderr 'error:cannot read CUE path: open gopmextra/foo.cue: no such file or directory'
 
 -- gopmconfig/config.cue --
 package config
@@ -7,13 +7,4 @@ package config
 config: grpc_server: {
 	network: "unix"
 	address: "gopm.socket"
-}
-
--- gopmextra/options.cue --
-package config
-
-config: programs: sleeper: {
-	command: """
-		echo hello
-		"""
 }

--- a/cmd/gopmctl/gopmctlcmd/main.go
+++ b/cmd/gopmctl/gopmctlcmd/main.go
@@ -76,7 +76,7 @@ func (ctl *Control) getServerURL() string {
 	if ctl.Address != "" {
 		return ctl.Address
 	} else if _, err := os.Stat(ctl.Configuration); err == nil {
-		cfg, err := config.Load(ctl.Configuration, nil)
+		cfg, err := config.Load(ctl.Configuration, nil, nil)
 		if err == nil {
 			// TODO return error from getServerURL
 			svr := cfg.GRPCServer

--- a/config/config.go
+++ b/config/config.go
@@ -100,7 +100,7 @@ func load0(configDir string, tags []string, paths []string) (*Config, error) {
 
 		by, err := os.ReadFile(path)
 		if err != nil {
-			return nil, fmt.Errorf("cannot read CUE path %q: %w", path, err)
+			return nil, fmt.Errorf("cannot read CUE file: %w", path, err)
 		}
 
 		fi, err := parser.ParseFile(path, by)

--- a/config/config.go
+++ b/config/config.go
@@ -89,18 +89,9 @@ func load0(configDir string, tags []string, paths []string) (*Config, error) {
 	}
 
 	for _, path := range paths {
-		if fi, err := os.Stat(path); err != nil {
-			if os.IsNotExist(err) {
-				return nil, fmt.Errorf("cannot load CUE path %q: path does not exist", path)
-			}
-			return nil, fmt.Errorf("cannot load CUE path %q: %w", path, err)
-		} else if fi.IsDir() {
-			return nil, fmt.Errorf("CUE path must be a file, found directory %q", path)
-		}
-
 		by, err := os.ReadFile(path)
 		if err != nil {
-			return nil, fmt.Errorf("cannot read CUE path %q: %w", path, err)
+			return nil, fmt.Errorf("cannot read CUE path: %w", err)
 		}
 
 		fi, err := parser.ParseFile(path, by)

--- a/supervisor.go
+++ b/supervisor.go
@@ -27,6 +27,7 @@ type Supervisor struct {
 	rpc.UnimplementedGopmServer
 	configFile string
 	tags       []string
+	paths      []string
 	procMgr    *process.Manager // process manager
 
 	// mu guards the fields below it.
@@ -39,10 +40,11 @@ type Supervisor struct {
 }
 
 // NewSupervisor create a Supervisor object with supervisor configuration file and configuration tags.
-func NewSupervisor(configFile string, tags []string) *Supervisor {
+func NewSupervisor(configFile string, tags []string, paths []string) *Supervisor {
 	return &Supervisor{
 		configFile: configFile,
 		tags:       tags,
+		paths:      paths,
 		procMgr:    process.NewManager(),
 		config:     new(config.Config),
 		done:       make(chan struct{}),
@@ -80,7 +82,7 @@ func (s *Supervisor) Done() <-chan struct{} {
 // Reload reloads the supervisor configuration
 func (s *Supervisor) Reload() error {
 	zap.L().Info("reloading configuration")
-	newConfig, err := config.Load(s.configFile, s.tags)
+	newConfig, err := config.Load(s.configFile, s.tags, s.paths)
 	if err != nil {
 		zap.L().Error("Error loading configuration", zap.Error(err))
 		var configErr *config.ConfigError


### PR DESCRIPTION
This PR adds the ability to specify additional CUE files to unify with the base configuration. An example use case it refer to additional options in an alternate directory that will be unified with a base configuration. For example, `gopm` is invoked with the `-c` argument referring to a directory containing the following `.cue` file:

```cue
opt: path: *"" | string
```

Additionally, the `-p` argument may refer to an additional file, such as:

```cue
opt: path: "/to/some/path"
```

Resulting in a unified version on the configuration `opt: path: "/to/some/path"`

This feature will be useful for separating configuration that is specific to a user / system from a base set of configuration files.

Signed-off-by: Stuart Carnie <stuart.carnie@gmail.com>